### PR TITLE
add release and publish workflows

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -1,0 +1,207 @@
+name: Create Release PR
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - release/*
+
+permissions:
+  pull-requests: write
+
+concurrency: "${{ github.workflow }}-${{ github.ref }}"
+
+env:
+  NODE_VERSION: "18.19.1"
+
+jobs:
+  detect-new-version:
+    name: Detect New Version
+    runs-on: ubuntu-latest
+    outputs:
+      NEW_VERSION_TAG: ${{ steps.detect-version.outputs.NEW_VERSION_TAG }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0  # fetch all history for all tags and branches
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Install Yarn
+        run: npm install -g yarn
+
+      - name: Detect New Version
+        id: detect-version
+        run: |
+          NEW_VERSION=$(yarn --silent version:current)
+          git diff origin/main.. -- package.json | grep "\"version\": \"${NEW_VERSION}\"" > /dev/null && HAS_VERSION_CHANGE=0 || HAS_VERSION_CHANGE=1
+          echo "HAS_VERSION_CHANGE=${HAS_VERSION_CHANGE}"
+
+          if [ $HAS_VERSION_CHANGE -eq 0 ]; then
+            echo "New version detected ${NEW_VERSION}"
+
+            echo "IS_NEW_VERSION=true" >> $GITHUB_OUTPUT
+            echo "NEW_VERSION=${NEW_VERSION}" >> $GITHUB_OUTPUT
+            echo "NEW_VERSION_TAG=v${NEW_VERSION}" >> $GITHUB_OUTPUT
+          else
+            echo "No version change detected, exiting"
+            exit 1
+          fi
+
+      - name: Verify Release Changes
+        if: ${{ steps.detect-version.outputs.IS_NEW_VERSION == 'true' }}
+        run: |
+          echo "IS_NEW_VERSION=${{ steps.detect-version.outputs.IS_NEW_VERSION }}"
+          echo "NEW_VERSION=${{ steps.detect-version.outputs.NEW_VERSION }}"
+          echo "NEW_VERSION_TAG=${{ steps.detect-version.outputs.NEW_VERSION_TAG }}"
+
+          function verify_file_has_diff_with_version() {
+            FILE_NAME=$1
+            FILE_DIFF="$(git diff origin/main.. -- ${FILE_NAME})"
+
+            echo "Diff in $FILE_NAME:\n$FILE_DIFF"
+
+            if [ "$(echo "${FILE_DIFF}" | wc -l)" -eq 0 ]; then
+              echo "No diff detected in $FILE_NAME, exiting"
+              exit 1
+            fi
+
+            HAS_VERSION_IN_FILE=$([ "$(echo "${FILE_DIFF}" | grep -c "${{ steps.detect-version.outputs.NEW_VERSION }}")" -gt 0 ] && echo "true" || echo "false")
+
+            if [ "$HAS_VERSION_IN_FILE" = "true" ]; then
+              echo "Detected changes in $FILE_NAME that include the new version (as expected)"
+            else
+              echo "Detected changes in $FILE_NAME that don't contain the new version, exiting"
+              exit 1
+            fi
+          }
+
+          verify_file_has_diff_with_version CHANGELOG.md
+          verify_file_has_diff_with_version package.json
+
+          NUM_FILES_HAVE_DIFF="$(git --no-pager diff origin/main.. --name-only | wc -l | xargs)"
+          if [ "$NUM_FILES_HAVE_DIFF" -ne 2 ]; then
+            echo "Release PR can only edit 2 files: CHANGELOG.md and package.json, exiting"
+            exit 1
+          fi
+
+  create-pr:
+    name: Create PR
+    runs-on: ubuntu-latest
+    needs: detect-new-version
+    env:
+      NEW_VERSION_TAG: ${{ needs.detect-new-version.outputs.NEW_VERSION_TAG }}
+    outputs:
+      CREATE_PR_SUCCESS: ${{ steps.create-pr-gh-cli.outputs.CREATE_PR_SUCCESS }}
+      CREATED_PR_URL: ${{ steps.create-pr-gh-cli.outputs.CREATED_PR_URL }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0  # fetch all history for all tags and branches
+
+      - name: Generate Github API Token
+        id: generate-gh-token
+        uses: actions/create-github-app-token@v1
+        env:
+          # The app is owned by @gilmeir-arnac, settings: https://github.com/settings/apps/create-pr-from-github-actions
+          GITHUB_CREATE_PR_APP_ID: "896608"
+          GITHUB_CREATE_PR_APP_PRIVATE_KEY: ${{ secrets.CREATE_PR_APP_PRIVATE_KEY }}
+          # Installation of the app in this organization, see: https://github.com/FordefiHQ/web3-provider/settings/installations
+          GITHUB_CREATE_PR_APP_INSTALLATION_ID_IN_ORG: "50650204"
+        with:
+          app-id: ${{ env.GITHUB_CREATE_PR_APP_ID }}
+          private-key: ${{ env.GITHUB_CREATE_PR_APP_PRIVATE_KEY }}
+
+      - name: Create Pull Request
+        id: create-pr-gh-cli
+        env:
+          GH_TOKEN: ${{ steps.generate-gh-token.outputs.token }}
+        run: |
+          # verify token works
+          gh api octocat
+
+          # create PR
+          gh pr create \
+            --base gil/main-clone \
+            --head "${{ github.ref_name }}" \
+            --title "Release ${{ env.NEW_VERSION_TAG }}" \
+            --body "
+            - [ ] Bump the version in package.json.
+            - [ ] Update CHANGELOG.md.
+            " \
+            --reviewer "gilmeir-arnac" \
+            --assignee "${{ github.actor }}"
+
+          echo "CREATE_PR_SUCCESS=$( [ $? -eq 0 ] && echo "true" || echo "false" )" >> $GITHUB_OUTPUT
+
+          CREATED_PR_URL="$(gh pr list --repo ${{ github.repository }} --head ${{ github.ref_name }} --base main --limit 1 --json url --jq ".[].url")"
+          echo "CREATED_PR_URL=$CREATED_PR_URL" >> $GITHUB_OUTPUT
+
+  report-to-slack:
+    name: Report Result to Slack
+    if: always()
+    runs-on: ubuntu-latest
+    needs: [detect-new-version, create-pr]
+    env:
+      NEW_VERSION_TAG: ${{ needs.detect-new-version.outputs.NEW_VERSION_TAG }}
+      CREATE_PR_SUCCESS: ${{ needs.create-pr.outputs.CREATE_PR_SUCCESS }}
+      CREATED_PR_URL: ${{ needs.create-pr.outputs.CREATED_PR_URL }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      # channel #web3-provider-releases
+      SLACK_CHANNEL_ID: "C072BEST4AC"
+      WORKFLOW_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+    steps:
+      - name: Notify Slack on Success
+        if: ${{ env.CREATE_PR_SUCCESS == 'true' }}
+        uses: slackapi/slack-github-action@v1.26.0
+        with:
+          channel-id: ${{ env.SLACK_CHANNEL_ID }}
+          # Slack Block Kit API: https://api.slack.com/reference/block-kit
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*Release `${{ env.NEW_VERSION_TAG }}` is waiting for approval*  |  <${{ env.CREATED_PR_URL }}|Pull Request>  |  <${{ env.WORKFLOW_URL }}|Workflow>"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Initiated by `${{ github.actor }}` from branch `${{ github.ref_name }}`"
+                  }
+                }
+              ]
+            }
+
+      - name: Notify Slack on Failure
+        if: ${{ env.CREATE_PR_SUCCESS != 'true' }}
+        uses: slackapi/slack-github-action@v1.26.0
+        with:
+          channel-id: ${{ env.SLACK_CHANNEL_ID }}
+          # Slack Block Kit API: https://api.slack.com/reference/block-kit
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*Failed to create a release for `${{ env.NEW_VERSION_TAG }}`*  |  <${{ env.WORKFLOW_URL }}|Workflow>"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Initiated by `${{ github.actor }}` from branch `${{ github.ref_name }}`"
+                  }
+                }
+              ]
+            }

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -104,6 +104,7 @@ jobs:
 
       - name: Generate Github API Token
         id: generate-gh-token
+        # this action outputs `token`
         uses: actions/create-github-app-token@v1
         env:
           # The app is owned by @gilmeir-arnac, settings: https://github.com/settings/apps/create-pr-from-github-actions

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -13,6 +13,7 @@ concurrency: "${{ github.workflow }}-${{ github.ref }}"
 
 env:
   NODE_VERSION: "18.19.1"
+  SLACK_CHANNEL_ID: "C072BEST4AC" # channel #web3-provider-releases
 
 jobs:
   detect-new-version:
@@ -36,6 +37,8 @@ jobs:
       - name: Detect New Version
         id: detect-version
         run: |
+          set -e
+
           NEW_VERSION=$(yarn --silent version:current)
           git diff origin/main.. -- package.json | grep "\"version\": \"${NEW_VERSION}\"" > /dev/null && HAS_VERSION_CHANGE=0 || HAS_VERSION_CHANGE=1
           echo "HAS_VERSION_CHANGE=${HAS_VERSION_CHANGE}"
@@ -54,6 +57,8 @@ jobs:
       - name: Verify Release Changes
         if: ${{ steps.detect-version.outputs.IS_NEW_VERSION == 'true' }}
         run: |
+          set -e
+
           echo "IS_NEW_VERSION=${{ steps.detect-version.outputs.IS_NEW_VERSION }}"
           echo "NEW_VERSION=${{ steps.detect-version.outputs.NEW_VERSION }}"
           echo "NEW_VERSION_TAG=${{ steps.detect-version.outputs.NEW_VERSION_TAG }}"
@@ -69,19 +74,21 @@ jobs:
               exit 1
             fi
 
-            HAS_VERSION_IN_FILE=$([ "$(echo "${FILE_DIFF}" | grep -c "${{ steps.detect-version.outputs.NEW_VERSION }}")" -gt 0 ] && echo "true" || echo "false")
+            NUM_DIFF_LINES_WITH_VERSION=$(echo "${FILE_DIFF}" | grep -c "${{ steps.detect-version.outputs.NEW_VERSION }}" || true)
 
-            if [ "$HAS_VERSION_IN_FILE" = "true" ]; then
-              echo "Detected changes in $FILE_NAME that include the new version (as expected)"
-            else
-              echo "Detected changes in $FILE_NAME that don't contain the new version, exiting"
+            if [ $NUM_DIFF_LINES_WITH_VERSION -eq 0 ]; then
+              echo "$FILE_NAME does not contain the new version, exiting"
               exit 1
             fi
+
+            echo "$FILE_NAME contains the new version as expected"
           }
 
+          # verify each file has the new version in diff
           verify_file_has_diff_with_version CHANGELOG.md
           verify_file_has_diff_with_version package.json
 
+          # verify only relevant files have changes
           NUM_FILES_HAVE_DIFF="$(git --no-pager diff origin/main.. --name-only | wc -l | xargs)"
           if [ "$NUM_FILES_HAVE_DIFF" -ne 2 ]; then
             echo "Release PR can only edit 2 files: CHANGELOG.md and package.json, exiting"
@@ -94,9 +101,6 @@ jobs:
     needs: detect-new-version
     env:
       NEW_VERSION_TAG: ${{ needs.detect-new-version.outputs.NEW_VERSION_TAG }}
-    outputs:
-      CREATE_PR_SUCCESS: ${{ steps.create-pr-gh-cli.outputs.CREATE_PR_SUCCESS }}
-      CREATED_PR_URL: ${{ steps.create-pr-gh-cli.outputs.CREATED_PR_URL }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -121,6 +125,8 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.generate-gh-token.outputs.token }}
         run: |
+          set -e
+
           # verify token works
           gh api octocat
 
@@ -136,28 +142,17 @@ jobs:
             --reviewer "gilmeir-arnac" \
             --assignee "${{ github.actor }}"
 
-          echo "CREATE_PR_SUCCESS=$( [ $? -eq 0 ] && echo "true" || echo "false" )" >> $GITHUB_OUTPUT
-
           CREATED_PR_URL="$(gh pr list --repo ${{ github.repository }} --head ${{ github.ref_name }} --base main --limit 1 --json url --jq ".[].url")"
           echo "CREATED_PR_URL=$CREATED_PR_URL" >> $GITHUB_OUTPUT
 
-  report-to-slack:
-    name: Report Result to Slack
-    if: always()
-    runs-on: ubuntu-latest
-    needs: [detect-new-version, create-pr]
-    env:
-      NEW_VERSION_TAG: ${{ needs.detect-new-version.outputs.NEW_VERSION_TAG }}
-      CREATE_PR_SUCCESS: ${{ needs.create-pr.outputs.CREATE_PR_SUCCESS }}
-      CREATED_PR_URL: ${{ needs.create-pr.outputs.CREATED_PR_URL }}
-      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-      # channel #web3-provider-releases
-      SLACK_CHANNEL_ID: "C072BEST4AC"
-      WORKFLOW_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-    steps:
       - name: Notify Slack on Success
-        if: ${{ env.CREATE_PR_SUCCESS == 'true' }}
+        if: success()
         uses: slackapi/slack-github-action@v1.26.0
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          NEW_VERSION_TAG: ${{ needs.detect-new-version.outputs.NEW_VERSION_TAG }}
+          CREATED_PR_URL: ${{ steps.create-pr-gh-cli.outputs.CREATED_PR_URL }}
+          WORKFLOW_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         with:
           channel-id: ${{ env.SLACK_CHANNEL_ID }}
           # Slack Block Kit API: https://api.slack.com/reference/block-kit
@@ -182,8 +177,12 @@ jobs:
             }
 
       - name: Notify Slack on Failure
-        if: ${{ env.CREATE_PR_SUCCESS != 'true' }}
+        if: failure()
         uses: slackapi/slack-github-action@v1.26.0
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          NEW_VERSION_TAG: ${{ needs.detect-new-version.outputs.NEW_VERSION_TAG }}
+          WORKFLOW_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         with:
           channel-id: ${{ env.SLACK_CHANNEL_ID }}
           # Slack Block Kit API: https://api.slack.com/reference/block-kit

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -1,13 +1,16 @@
 name: Run checks on Pull Requests
+
 on:
   pull_request:
+
+concurrency: "${{ github.workflow }}-${{ github.ref }}"
 
 jobs:
   build_lint:
     name: Lint & Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup Node.js
         uses: actions/setup-node@v3

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -132,7 +132,7 @@ jobs:
 
       - name: Generate Github API Token
         id: generate-gh-token
-        # the token is an output `token`
+        # this action outputs `token`
         uses: actions/create-github-app-token@v1
         env:
           # The app is owned by @gilmeir-arnac, settings: https://github.com/settings/apps/create-pr-from-github-actions

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,206 @@
+name: Publish Release
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    types:
+     - closed
+
+permissions:
+  contents: write
+
+concurrency: "${{ github.workflow }}-${{ github.ref }}"
+
+env:
+  NODE_VERSION: "18.19.1"
+  # channel #web3-provider-releases
+  SLACK_CHANNEL_ID: "C072BEST4AC"
+  PACKAGE_NAME: "@fordefi/web3-provider"
+  WORKFLOW_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+  GITHUB_PR_URL: ${{ github.event.pull_request.html_url }}
+
+jobs:
+  publish-to-npm:
+    name: Publish to NPM
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/') }}
+    outputs:
+      NEW_VERSION_TAG: ${{ steps.get-release-version.outputs.NEW_VERSION_TAG }}
+      NPM_PUBLISH_SUCCESS: ${{ steps.publish-to-npm.outputs.NPM_PUBLISH_SUCCESS }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0  # fetch all history for all tags and branches
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Install Yarn
+        run: npm install -g yarn
+
+      - name: Install Dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Create .npmrc
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          cat << EOF > "$HOME/.npmrc"
+            //registry.npmjs.org/:_authToken=$NPM_TOKEN
+          EOF
+
+      - name: Get Release Version and Tag
+        id: get-release-version
+        run: |
+          NEW_VERSION="$(yarn --silent version:current)"
+          echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
+
+          NEW_VERSION_TAG="v${NEW_VERSION}"
+          echo "NEW_VERSION_TAG=$NEW_VERSION_TAG" >> $GITHUB_ENV
+          echo "NEW_VERSION_TAG=$NEW_VERSION_TAG" >> $GITHUB_OUTPUT
+
+      - name: Publish to NPM
+        id: publish-to-npm
+        run: |
+          echo "Publishing version $NEW_VERSION to NPM..."
+
+          yarn publish:latest
+
+          NPM_PUBLISH_SUCCESS=$([ $? -eq 0 ] && echo "true" || echo "false")
+          echo "NPM_PUBLISH_SUCCESS=$NPM_PUBLISH_SUCCESS" >> $GITHUB_ENV
+          echo "NPM_PUBLISH_SUCCESS=$NPM_PUBLISH_SUCCESS" >> $GITHUB_OUTPUT
+
+      - name: Notify Slack on Success
+        if: ${{ env.NPM_PUBLISH_SUCCESS == 'true' }}
+        uses: slackapi/slack-github-action@v1.26.0
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          GITHUB_TAG_URL: "${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ env.NEW_VERSION_TAG }}"
+          NPM_RELEASE_URL: "https://www.npmjs.com/package/${{ env.PACKAGE_NAME }}/v/${{ env.NEW_VERSION }}"
+        with:
+          channel-id: ${{ env.SLACK_CHANNEL_ID }}
+          # Slack Block Kit API: https://api.slack.com/reference/block-kit
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*Release `${{ env.NEW_VERSION_TAG }}` was successfully published to NPM*   |   <${{ env.NPM_RELEASE_URL }}|NPM>   |   <${{ env.GITHUB_TAG_URL }}|Tag>   |   <${{ env.WORKFLOW_URL }}|Workflow>   |   <${{ env.GITHUB_PR_URL }}|Pull Request>"
+                  }
+                }
+              ]
+            }
+
+      - name: Notify Slack on Failure
+        if: ${{ env.NPM_PUBLISH_SUCCESS != 'true' }}
+        uses: slackapi/slack-github-action@v1.26.0
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        with:
+          channel-id: ${{ env.SLACK_CHANNEL_ID }}
+          # Slack Block Kit API: https://api.slack.com/reference/block-kit
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*Release `${{ env.NEW_VERSION_TAG }}` failed to publish to NPM*   |   <${{ env.WORKFLOW_URL }}|Workflow>   |   <${{ env.GITHUB_PR_URL }}|Pull Request>"
+                  }
+                }
+              ]
+            }
+
+  create-tag:
+    name: Create Tag
+    needs: publish-to-npm
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/') && needs.publish-to-npm.outputs.NPM_PUBLISH_SUCCESS == 'true'}}
+    env:
+      NEW_VERSION_TAG: ${{ needs.publish-to-npm.outputs.NEW_VERSION_TAG }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0  # fetch all history for all tags and branches
+
+      - name: Generate Github API Token
+        id: generate-gh-token
+        # the token is an output `token`
+        uses: actions/create-github-app-token@v1
+        env:
+          # The app is owned by @gilmeir-arnac, settings: https://github.com/settings/apps/create-pr-from-github-actions
+          GITHUB_CREATE_PR_APP_ID: "896608"
+          GITHUB_CREATE_PR_APP_PRIVATE_KEY: ${{ secrets.CREATE_PR_APP_PRIVATE_KEY }}
+        with:
+          app-id: ${{ env.GITHUB_CREATE_PR_APP_ID }}
+          private-key: ${{ env.GITHUB_CREATE_PR_APP_PRIVATE_KEY }}
+
+      - name: Create Tag
+        env:
+          GH_TOKEN: ${{ steps.generate-gh-token.outputs.token }}
+        run: |
+          # verify token works
+          gh api octocat
+
+          echo "Creating tag ${{ env.NEW_VERSION_TAG }} at commit $HEAD_COMMIT_HASH"
+
+          HEAD_COMMIT_HASH=$(git rev-parse HEAD)
+          DATA='{"ref": "refs/tags/${{ env.NEW_VERSION_TAG }}","sha": "'$HEAD_COMMIT_HASH'"}'
+
+          curl -X POST \
+            -H "Authorization: Bearer ${{ env.GH_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            -d "$DATA" \
+            https://api.github.com/repos/${{ github.repository }}/git/refs
+
+          CREATE_TAG_SUCCESS=$( [ $? -eq 0 ] && echo "true" || echo "false" )
+          echo "CREATE_TAG_SUCCESS=$CREATE_TAG_SUCCESS" >> $GITHUB_ENV
+
+      - name: Notify Slack on Success
+        if: ${{ env.CREATE_TAG_SUCCESS == 'true' }}
+        uses: slackapi/slack-github-action@v1.26.0
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        with:
+          channel-id: ${{ env.SLACK_CHANNEL_ID }}
+          # Slack Block Kit API: https://api.slack.com/reference/block-kit
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Tag `${{ env.NEW_VERSION_TAG }}` was successfully created"
+                  }
+                }
+              ]
+            }
+
+      - name: Notify Slack on Failure
+        if: ${{ env.CREATE_TAG_SUCCESS != 'true' }}
+        uses: slackapi/slack-github-action@v1.26.0
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        with:
+          channel-id: ${{ env.SLACK_CHANNEL_ID }}
+          # Slack Block Kit API: https://api.slack.com/reference/block-kit
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Tag `${{ env.NEW_VERSION_TAG }}` failed to be published*   |   <${{ env.WORKFLOW_URL }}|Workflow>"
+                  }
+                }
+              ]
+            }

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -15,8 +15,7 @@ concurrency: "${{ github.workflow }}-${{ github.ref }}"
 
 env:
   NODE_VERSION: "18.19.1"
-  # channel #web3-provider-releases
-  SLACK_CHANNEL_ID: "C072BEST4AC"
+  SLACK_CHANNEL_ID: "C072BEST4AC" # channel #web3-provider-releases
   PACKAGE_NAME: "@fordefi/web3-provider"
   WORKFLOW_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
   GITHUB_PR_URL: ${{ github.event.pull_request.html_url }}
@@ -28,7 +27,6 @@ jobs:
     if: ${{ github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/') }}
     outputs:
       NEW_VERSION_TAG: ${{ steps.get-release-version.outputs.NEW_VERSION_TAG }}
-      NPM_PUBLISH_SUCCESS: ${{ steps.publish-to-npm.outputs.NPM_PUBLISH_SUCCESS }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -56,6 +54,8 @@ jobs:
       - name: Get Release Version and Tag
         id: get-release-version
         run: |
+          set -e
+
           NEW_VERSION="$(yarn --silent version:current)"
           echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
 
@@ -66,16 +66,13 @@ jobs:
       - name: Publish to NPM
         id: publish-to-npm
         run: |
-          echo "Publishing version $NEW_VERSION to NPM..."
+          set -e
 
+          echo "Publishing version $NEW_VERSION to NPM..."
           yarn publish:latest
 
-          NPM_PUBLISH_SUCCESS=$([ $? -eq 0 ] && echo "true" || echo "false")
-          echo "NPM_PUBLISH_SUCCESS=$NPM_PUBLISH_SUCCESS" >> $GITHUB_ENV
-          echo "NPM_PUBLISH_SUCCESS=$NPM_PUBLISH_SUCCESS" >> $GITHUB_OUTPUT
-
       - name: Notify Slack on Success
-        if: ${{ env.NPM_PUBLISH_SUCCESS == 'true' }}
+        if: success()
         uses: slackapi/slack-github-action@v1.26.0
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
@@ -98,7 +95,7 @@ jobs:
             }
 
       - name: Notify Slack on Failure
-        if: ${{ env.NPM_PUBLISH_SUCCESS != 'true' }}
+        if: failure()
         uses: slackapi/slack-github-action@v1.26.0
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
@@ -122,7 +119,7 @@ jobs:
     name: Create Tag
     needs: publish-to-npm
     runs-on: ubuntu-latest
-    if: ${{ github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/') && needs.publish-to-npm.outputs.NPM_PUBLISH_SUCCESS == 'true'}}
+    if: ${{ github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/') }}
     env:
       NEW_VERSION_TAG: ${{ needs.publish-to-npm.outputs.NEW_VERSION_TAG }}
     steps:
@@ -146,6 +143,8 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.generate-gh-token.outputs.token }}
         run: |
+          set -e
+
           # verify token works
           gh api octocat
 
@@ -160,11 +159,8 @@ jobs:
             -d "$DATA" \
             https://api.github.com/repos/${{ github.repository }}/git/refs
 
-          CREATE_TAG_SUCCESS=$( [ $? -eq 0 ] && echo "true" || echo "false" )
-          echo "CREATE_TAG_SUCCESS=$CREATE_TAG_SUCCESS" >> $GITHUB_ENV
-
       - name: Notify Slack on Success
-        if: ${{ env.CREATE_TAG_SUCCESS == 'true' }}
+        if: success()
         uses: slackapi/slack-github-action@v1.26.0
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
@@ -185,7 +181,7 @@ jobs:
             }
 
       - name: Notify Slack on Failure
-        if: ${{ env.CREATE_TAG_SUCCESS != 'true' }}
+        if: failure()
         uses: slackapi/slack-github-action@v1.26.0
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+## 0.2.0 (2024-05-07)
+- Added README & JSDoc comments.
+- Added `typedoc` to generate docs from JSDoc comments and Typescript types in markdown & html.
+- Changed RPC methods schema - split to `FordefiRpcSchema` and `NonFordefiRpcSchema`.
+- Changed `target` in `tsconfig.json` to `ES2020`.
+- Removed user info functionality.
+- Fixed `lint-staged` glob pattern.
+- Fixed broken error handling of Fordefi API errors.
+
+## 0.1.0 (2024-05-01)
+- Added `FordefiWeb3Provider` - an HTTP JSON RPC Web3 Provider compatible with [EIP-1193](https://eips.ethereum.org/EIPS/eip-1193).

--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ console.log(`Transaction hash: ${txHash}`);
 
 ## API Reference
 
+The full API reference is available on the [Fordefi Web3 Provider docs site](https://web3provider-docs.fordefi.com).
+
 ### Configuration
 
 For details, see the [FordefiProviderConfig](./src/types/config.ts) interface.

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "test": "jest",
     "publish:dev": "yarn build && yarn typedoc:gen:html && yarn publish --no-git-tag-version --tag beta",
     "publish:latest": "yarn build && yarn typedoc:gen:html && yarn publish --tag latest",
+    "version:current": "echo ${npm_package_version}",
     "version:beta": "echo \"${npm_package_version}-dev.$(git rev-parse --short HEAD)\"",
     "typedoc:gen:html": "typedoc --options typedoc-html.json",
     "typedoc:gen:md": "typedoc --options typedoc-md.json",


### PR DESCRIPTION
# Description
New workflows managing the release cycle 

Required secrets
* `CREATE_PR_APP_PRIVATE_KEY` - generated by a dedicated Github app `Create PR from Github Actions` owned by @gilmeir-arnac. The settings page is: https://github.com/settings/apps/create-pr-from-github-actions.
* `SLACK_BOT_TOKEN` - requires to send messages on workflows success/failure to Fordefi's private workspace in Slack - to the channel `#web3-provider-releases`.
* `NPM_TOKEN` - to publish new releases to npm.

Workflows
1. Create release
    - Verifies `CHANGELOG.md` and `package.json` diff contain the new release version, and only these 2 files changed
    - Creates a release pull request in a consistent way
    - Notifies to Slack
1. Publish release
    - Runs build and publishes to npm & reports result to Slack
    - Creates a tag and pushes to git & reports result to Slack

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/FordefiHQ/web3-provider/12)
<!-- Reviewable:end -->
