### PR TITLE
allow an empty value in `eth_sendTransaction`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fordefi/web3-provider",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Web3 Provider and signer compatible with EIP-1193",
   "author": "Gil Meir <gil@fordefi.com>",
   "homepage": "https://github.com/FordefiHQ/web3-provider",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fordefi/web3-provider",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Web3 Provider and signer compatible with EIP-1193",
   "author": "Gil Meir <gil@fordefi.com>",
   "homepage": "https://github.com/FordefiHQ/web3-provider",

--- a/src/provider/provider.types.ts
+++ b/src/provider/provider.types.ts
@@ -12,6 +12,9 @@ import {
 } from 'viem';
 import { OmitFromArray } from '../utils/types';
 
+// Fordefi API supports both hex strings and decimal string (so does the spec)
+export type FordefiWeb3TransactionRequest = TransactionRequest<bigint | Hex>;
+
 /** Spec of all methods implemented by Fordefi. */
 export type FordefiRpcSchema = readonly [
   {
@@ -31,12 +34,12 @@ export type FordefiRpcSchema = readonly [
   },
   {
     Method: 'eth_sendTransaction';
-    Parameters: [transaction: TransactionRequest];
+    Parameters: [transaction: FordefiWeb3TransactionRequest];
     ReturnType: Hash;
   },
   {
     Method: 'eth_signTransaction';
-    Parameters: [request: TransactionRequest];
+    Parameters: [request: FordefiWeb3TransactionRequest];
     ReturnType: Hex;
   },
   {

--- a/src/types/type-utils.ts
+++ b/src/types/type-utils.ts
@@ -1,0 +1,1 @@
+export type Defined<T> = T extends undefined ? never : T;

--- a/src/types/type-utils.ts
+++ b/src/types/type-utils.ts
@@ -1,1 +1,0 @@
-export type Defined<T> = T extends undefined ? never : T;

--- a/src/utils/transactions.ts
+++ b/src/utils/transactions.ts
@@ -172,8 +172,8 @@ export const buildEvmRawTransactionRequest = (
     );
   }
 
-  if (!to || !isAddress(to)) {
-    throw new InvalidParamsRpcError(new Error('Transaction "to" is either missing or invalid'));
+  if (to && !isAddress(to)) {
+    throw new InvalidParamsRpcError(new Error('Transaction "to" is not a valid address'));
   }
 
   return {
@@ -187,7 +187,8 @@ export const buildEvmRawTransactionRequest = (
       pushMode,
       chain: chain.chainId,
       value: parseTransactionRequestValueField(value),
-      to,
+      // @ts-expect-error TODO(gil): remove once API change is merged
+      to: to ?? undefined,
       data: data
         ? {
             type: EvmDataRequestHexTypeEnum.hex,

--- a/src/utils/transactions.ts
+++ b/src/utils/transactions.ts
@@ -28,7 +28,7 @@ import {
   PushMode,
   SignerType,
 } from '../openapi';
-import { FordefiRpcSchema, RequestArgs } from '../provider/provider.types';
+import { FordefiRpcSchema, FordefiWeb3TransactionRequest, RequestArgs } from '../provider/provider.types';
 import { AnyEvmTransaction, EvmVault } from '../types';
 import { waitFor } from './wait-for';
 
@@ -122,7 +122,7 @@ const toFordefiEvmGas = ({
   maxFeePerGas,
   gasPrice,
   gas,
-}: Partial<TransactionRequest>): CreateEvmRawTransactionRequestGas => {
+}: Partial<FordefiWeb3TransactionRequest>): CreateEvmRawTransactionRequestGas => {
   const gasLimit = parseTransactionRequestNumericField('gas', gas);
 
   if (maxPriorityFeePerGas !== undefined && maxFeePerGas !== undefined) {
@@ -156,7 +156,7 @@ const toFordefiEvmGas = ({
 };
 
 export const buildEvmRawTransactionRequest = (
-  transaction: Partial<TransactionRequest>,
+  transaction: Partial<FordefiWeb3TransactionRequest>,
   chain: EvmChain,
   vault: EvmVault,
   pushMode: PushMode,

--- a/src/utils/transactions.ts
+++ b/src/utils/transactions.ts
@@ -104,8 +104,9 @@ export const buildEvmRawTransactionRequest = (
     throw new InvalidParamsRpcError(new Error('Transaction "to" is either missing or invalid'));
   }
 
-  if (value === undefined || typeof value !== 'bigint') {
-    throw new InvalidParamsRpcError(new Error('Transaction "value" in either missing or invalid'));
+  const valueStr = value?.toString();
+  if (valueStr !== undefined && !valueStr.match(/^\d+$/)) {
+    throw new InvalidParamsRpcError(new Error('Transaction "value" must be a valid number'));
   }
 
   return {
@@ -118,7 +119,7 @@ export const buildEvmRawTransactionRequest = (
       skipPrediction: true,
       pushMode,
       chain: chain.chainId,
-      value: value.toString(),
+      value: valueStr ?? '0', // The spec defines it as optional, but it's required in our API
       to,
       data: data
         ? {

--- a/src/utils/transactions.ts
+++ b/src/utils/transactions.ts
@@ -21,7 +21,6 @@ import {
 } from '../openapi';
 import { FordefiRpcSchema, FordefiWeb3TransactionRequest, RequestArgs } from '../provider/provider.types';
 import { AnyEvmTransaction, EvmVault } from '../types';
-import { Defined } from '../types/type-utils';
 import { waitFor } from './wait-for';
 
 /**
@@ -32,11 +31,7 @@ import { waitFor } from './wait-for';
  * - BigInt
  * - undefined - translated to '0' per Fordefi API interface
  */
-const toFordefiTransactionNumericValue = <T>(value: Defined<T>): string => {
-  if (value === undefined) {
-    throw new Error('value cannot be an undefined');
-  }
-
+const toFordefiTransactionNumericValue = (value: unknown): string => {
   if (typeof value === 'string') {
     if (value.trim() === '') {
       throw new Error('value cannot be an empty string');

--- a/src/utils/transactions.ts
+++ b/src/utils/transactions.ts
@@ -21,6 +21,7 @@ import {
 } from '../openapi';
 import { FordefiRpcSchema, FordefiWeb3TransactionRequest, RequestArgs } from '../provider/provider.types';
 import { AnyEvmTransaction, EvmVault } from '../types';
+import { Defined } from '../types/type-utils';
 import { waitFor } from './wait-for';
 
 /**
@@ -29,9 +30,12 @@ import { waitFor } from './wait-for';
  * - String (decimal, hex)
  * - Number
  * - BigInt
- * - undefined - translated to '0' per Fordefi API interface
  */
-const toFordefiTransactionNumericValue = (value: unknown): string => {
+const toFordefiTransactionNumericValue = <T>(value: Defined<T>): string => {
+  if (value === undefined) {
+    throw new Error('value cannot be undefined');
+  }
+
   if (typeof value === 'string') {
     if (value.trim() === '') {
       throw new Error('value cannot be an empty string');

--- a/test/provider.test.ts
+++ b/test/provider.test.ts
@@ -244,13 +244,12 @@ describe('Web3 Provider', () => {
         expect(isHash(transactionHash)).toBeTruthy();
       });
 
-      test("'eth_sendTransaction' given no 'value' should return a mined transaction hash", async () => {
+      test("'eth_sendTransaction' given no 'value' or 'to' should return a mined transaction hash", async () => {
         const provider = createTestProvider();
         await provider.waitForEmittedEvent('connect');
 
         const transaction = {
           from: TEST_PROVIDER_CONFIG.address,
-          to: testFixtures.toAddress,
           maxFeePerGas: numberToHex(150004177629n),
           maxPriorityFeePerGas: numberToHex(1000528647n),
           gas: numberToHex(22222n),

--- a/test/provider.test.ts
+++ b/test/provider.test.ts
@@ -17,7 +17,7 @@ import {
   TypedDataDefinition,
 } from 'viem';
 import { waitFor } from '../src/utils';
-import { FordefiRpcSchema, NonFordefiRpcSchema, RequestArgs } from '../src';
+import type { FordefiRpcSchema, NonFordefiRpcSchema, RequestArgs } from '../src/provider/provider.types';
 import { createTestProvider, minedTransactionFixture, TEST_PROVIDER_CONFIG, testFixtures } from './provider.test.utils';
 import msgParams from './fixtures/eth-sign-typed-data-v4-message.json';
 

--- a/test/provider.test.ts
+++ b/test/provider.test.ts
@@ -200,7 +200,7 @@ describe('Web3 Provider', () => {
     });
 
     describe('eth_sendTransaction', () => {
-      test("'eth_sendTransaction' given numbers as bigint should return a mined transaction hash", async () => {
+      test("'eth_sendTransaction' given quantities as bigint should return a mined transaction hash", async () => {
         const provider = createTestProvider();
         await provider.waitForEmittedEvent('connect');
 
@@ -222,7 +222,7 @@ describe('Web3 Provider', () => {
         expect(isHash(transactionHash)).toBeTruthy();
       });
 
-      test("'eth_sendTransaction' given number as hex strings should return a mined transaction hash", async () => {
+      test("'eth_sendTransaction' given quantities as hex strings should return a mined transaction hash", async () => {
         const provider = createTestProvider();
         await provider.waitForEmittedEvent('connect');
 
@@ -230,6 +230,27 @@ describe('Web3 Provider', () => {
           from: TEST_PROVIDER_CONFIG.address,
           to: testFixtures.toAddress,
           value: numberToHex(testFixtures.value),
+          maxFeePerGas: numberToHex(150004177629n),
+          maxPriorityFeePerGas: numberToHex(1000528647n),
+          gas: numberToHex(22222n),
+        } satisfies Partial<FordefiWeb3TransactionRequest>;
+
+        const transactionHash = await provider.request({
+          method: 'eth_sendTransaction',
+          params: [transaction],
+        });
+
+        console.debug(`Transaction hash: '${transactionHash}'`);
+        expect(isHash(transactionHash)).toBeTruthy();
+      });
+
+      test("'eth_sendTransaction' given no 'value' should return a mined transaction hash", async () => {
+        const provider = createTestProvider();
+        await provider.waitForEmittedEvent('connect');
+
+        const transaction = {
+          from: TEST_PROVIDER_CONFIG.address,
+          to: testFixtures.toAddress,
           maxFeePerGas: numberToHex(150004177629n),
           maxPriorityFeePerGas: numberToHex(1000528647n),
           gas: numberToHex(22222n),

--- a/test/provider.test.utils.ts
+++ b/test/provider.test.utils.ts
@@ -7,9 +7,13 @@ const sepoliaChainFixture = {
   uniqueId: EvmChainUniqueId.ethereumSepolia,
 };
 
+// "Gil Staging" organization, organizationId="20e0a222-2600-4cb7-8cad-f20650bf78aa"
+const fromAddress = '0xEb6852f573ad3c9562ad5BEe131A2251fd822131' as const satisfies Hex; // evm-1
+const toAddress = '0x46880C6712A2933769c50309298482ac061680c4' as const satisfies Hex; // evm-2
+
 export const TEST_PROVIDER_CONFIG: FordefiProviderConfig = {
   chainId: sepoliaChainFixture.chainId,
-  address: '0xEb6852f573ad3c9562ad5BEe131A2251fd822131',
+  address: fromAddress,
   apiUserToken: env.API_USER_TOKEN,
   // pem generated with `openssl ecparam -genkey -name prime256v1 -noout -out private.pem` as described in the docs: https://docs.fordefi.com/reference/pair-an-api-client-with-the-api-signer
   apiPayloadSignKey: env.API_PAYLOAD_SIGNING_KEY,
@@ -20,7 +24,7 @@ export const TEST_PROVIDER_CONFIG: FordefiProviderConfig = {
 export const GWEI = BigInt(10 ** 9);
 
 export const testFixtures = {
-  toAddress: '0x46880C6712A2933769c50309298482ac061680c4' as const satisfies Hex,
+  toAddress,
   chainIdSepoliaHex: numberToHex(sepoliaChainFixture.chainId),
   value: 5n * GWEI,
 };


### PR DESCRIPTION
## Description

The Ethereum JSON-RPC [spec](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_sendtransaction) allows the value parameter to be optional. Our JSON-RPC provider SDK currently does not allow it to be empty, but it should. An empty `value` is transformed to `0` as the Fordefi API requires.

## Ticket
[DEV-15816](https://fordefi.atlassian.net/browse/DEV-15816)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/FordefiHQ/web3-provider/13)
<!-- Reviewable:end -->
