### PR TITLE
Cleanup script: remove unused openapi generator files

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -1,0 +1,34 @@
+# Developer Guide
+
+## Update OpenAPI
+
+1. Go to the `arnac` project
+2. Switch to the `production` branch
+3. install FE node modules `(cd frontend && yarn)`
+4. Generate the OpenAPI specs `./build.sh -t protoc-derived-sources && ./build.sh -t openapi-file-frontend && (cd frontend && yarn build)`
+5. Delete the `src/openapi/` directory from this project
+6. Copy the generated OpenAPI output dir from `arnac/frontend/packages/shared/src/openapi` to replace the deleted one here `web3-provider/src/openapi/`
+7. Run `yarn cleanup`
+8. Run `yarn lint:check` and fix any errors (try `yarn lint:fix`)
+9. Run `yarn ts:check` and fix any type errors
+10. Run `yarn build` and fix any errors
+11. Bump the version in `package.json` manually
+
+- Create a PR with the changes.
+
+## Deploy
+
+1. make sure to be on `main` branch without any changes.
+2. make sure the version in `package.json` is the next to deploy.
+3. Run `yarn build`
+
+### Beta Release
+
+1. Set the version in `package.json` to the output of `yarn version:beta`
+2. Run `yarn publish:dev`
+3. Revert the version in `package.json` back to the bumped version
+
+### Latest Release
+
+1. Run `yarn publish:latest`
+

--- a/scripts/cleanup.js
+++ b/scripts/cleanup.js
@@ -27,6 +27,30 @@ function log(message, color = 'reset') {
   }
 }
 
+function removeUnusedFiles() {
+  log('\n🧹 Removing unused files ...', 'yellow');
+  const targets = [
+    path.join(process.cwd(), 'src/openapi/.openapi-generator'),
+    path.join(process.cwd(), 'src/openapi/.openapi-generator-ignore'),
+  ];
+
+  for (const target of targets) {
+    try {
+      const stat = fs.statSync(target);
+      if (stat.isDirectory()) {
+        fs.rmSync(target, { recursive: true });
+      } else {
+        fs.unlinkSync(target);
+      }
+      log(`  Removed ${path.relative(process.cwd(), target)}`, 'green');
+    } catch (error) {
+      if (error.code !== 'ENOENT') {
+        log(`  Error removing ${path.relative(process.cwd(), target)}: ${error.message}`, 'red');
+      }
+    }
+  }
+}
+
 function removeLinterDisableComments() {
   log('\n🧹 Removing linter disable comments ...', 'yellow');
   const srcDir = path.join(process.cwd(), 'src/openapi');
@@ -310,6 +334,8 @@ function runCleanup(cleanupIteration) {
 
 function cleanup() {
   log('\nRunning cleanup...', 'cyan');
+
+  removeUnusedFiles();
 
   removeLinterDisableComments();
 


### PR DESCRIPTION
## Summary
- Implement `removeUnusedFiles()` in the cleanup script to delete `src/openapi/.openapi-generator` (directory) and `src/openapi/.openapi-generator-ignore` (file) after code generation
- Wire it into the `cleanup()` flow as the first step

## Test plan
- [ ] Run `node scripts/cleanup.js` after openapi generation and verify the `.openapi-generator` dir and `.openapi-generator-ignore` file are removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/FordefiHQ/web3-provider/24)
<!-- Reviewable:end -->
