### PR TITLE
Use OIDC for npm publish, remove NPM token verify step

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -107,6 +107,7 @@ jobs:
 
         with:
           node-version: ${{ env.NODE_VERSION }}
+          registry-url: 'https://registry.npmjs.org'
           cache: 'yarn'
 
       - name: Enable Corepack

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -120,7 +120,9 @@ jobs:
         run: yarn build
 
       - name: Publish to NPM
-        run: npm publish --provenance --access public
+        run: |
+          sed -i 's/${NODE_AUTH_TOKEN}//' "${NPM_CONFIG_USERCONFIG}"
+          npm publish --provenance --access public
 
       - name: Notify Slack on Success
         if: success()

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -119,11 +119,6 @@ jobs:
       - name: Build Package
         run: yarn build
 
-      - name: Verify NPM Token
-        run: |
-          set -e
-          npm whoami
-
       - name: Publish to NPM
         run: yarn publish:latest --provenance
 

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to release (optional - will use package.json if not provided)'
+        description: "Version to release (optional - will use package.json if not provided)"
         required: false
         type: string
 
@@ -15,12 +15,12 @@ permissions:
   contents: write
   id-token: write # for npm provenance
 
-concurrency: 
+concurrency:
   group: "release-${{ github.ref }}"
   cancel-in-progress: false
 
 env:
-  NODE_VERSION: "20"
+  NODE_VERSION: "24"
   SLACK_CHANNEL_ID: "C072BEST4AC"
   PACKAGE_NAME: "@fordefi/web3-provider"
   WORKFLOW_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
@@ -43,7 +43,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: 'yarn'
+          cache: "yarn"
+          registry-url: https://registry.npmjs.org
 
       - name: Enable Corepack
         run: corepack enable
@@ -59,7 +60,7 @@ jobs:
           else
             VERSION="$(yarn --silent version:current)"
           fi
-          
+
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "version-tag=v$VERSION" >> $GITHUB_OUTPUT
           echo "VERSION=$VERSION" >> $GITHUB_ENV
@@ -73,14 +74,14 @@ jobs:
             echo "should-release=false" >> $GITHUB_OUTPUT
             exit 1
           fi
-          
+
           # Check if git tag already exists
           if git tag -l "v$VERSION" | grep -q "v$VERSION"; then
             echo "❌ Git tag v$VERSION already exists"
             echo "should-release=false" >> $GITHUB_OUTPUT
             exit 1
           fi
-          
+
           echo "✅ Version $VERSION is ready for release"
           echo "should-release=true" >> $GITHUB_OUTPUT
 
@@ -104,11 +105,10 @@ jobs:
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
-
         with:
           node-version: ${{ env.NODE_VERSION }}
-          registry-url: 'https://registry.npmjs.org'
-          cache: 'yarn'
+          cache: "yarn"
+          registry-url: https://registry.npmjs.org
 
       - name: Enable Corepack
         run: corepack enable
@@ -120,7 +120,12 @@ jobs:
         run: yarn build
 
       - name: Publish to NPM
-        run: yarn publish:latest --provenance
+        run: |
+          yarn publish:latest
+        env:
+          NODE_AUTH_TOKEN: ""
+          NPM_CONFIG_REGISTRY: "https://registry.npmjs.org"
+          
 
       - name: Notify Slack on Success
         if: success()
@@ -235,4 +240,4 @@ jobs:
                   }
                 }
               ]
-            } 
+            }

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -119,17 +119,8 @@ jobs:
       - name: Build Package
         run: yarn build
 
-      - name: Verify NPM Token
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          set -e
-          npm whoami
-
       - name: Publish to NPM
-        run: yarn publish:latest --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --provenance --access public
 
       - name: Notify Slack on Success
         if: success()

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -107,7 +107,6 @@ jobs:
 
         with:
           node-version: ${{ env.NODE_VERSION }}
-          registry-url: 'https://registry.npmjs.org'
           cache: 'yarn'
 
       - name: Enable Corepack

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -119,10 +119,13 @@ jobs:
       - name: Build Package
         run: yarn build
 
-      - name: Publish to NPM
+      - name: Verify NPM Token
         run: |
-          sed -i 's/${NODE_AUTH_TOKEN}//' "${NPM_CONFIG_USERCONFIG}"
-          npm publish --provenance --access public
+          set -e
+          npm whoami
+
+      - name: Publish to NPM
+        run: yarn publish:latest --provenance
 
       - name: Notify Slack on Success
         if: success()

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org

--- a/fordicode-project/main/context.md
+++ b/fordicode-project/main/context.md
@@ -1,0 +1,3 @@
+# Context
+
+(Record key decisions and insights here)

--- a/fordicode-project/uri-oidc-npm-publish/context.md
+++ b/fordicode-project/uri-oidc-npm-publish/context.md
@@ -1,0 +1,3 @@
+# Context
+
+(Record key decisions and insights here)

--- a/package.json
+++ b/package.json
@@ -7,13 +7,9 @@
   "issues": "https://github.com/FordefiHQ/web3-provider/issues",
   "repository": {
     "type": "git",
-    "url": "git@github.com:FordefiHQ/web3-provider.git"
+    "url": "https://github.com/FordefiHQ/web3-provider.git"
   },
   "private": false,
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org",
-    "access": "public"
-  },
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
@@ -41,7 +37,7 @@
     "build": "yarn clean && tsup-node src/index.ts --format cjs,esm --dts",
     "test": "jest",
     "publish:dev": "yarn build && yarn typedoc:gen:html && yarn publish --no-git-tag-version --tag beta",
-    "publish:latest": "yarn build && yarn typedoc:gen:html && yarn publish --tag latest",
+    "publish:latest": "yarn build && yarn typedoc:gen:html && npm publish --tag latest --provenance",
     "version:current": "echo ${npm_package_version}",
     "version:beta": "echo \"${npm_package_version}-dev.$(git rev-parse --short HEAD)\"",
     "typedoc:gen:html": "typedoc --options typedoc-html.json",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,10 @@
     "url": "git@github.com:FordefiHQ/web3-provider.git"
   },
   "private": false,
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org",
+    "access": "public"
+  },
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

- Remove the unnecessary `npm whoami` verification step — not needed with OIDC provenance (`id-token: write` is already configured)
- Minor formatting cleanup (quotes, trailing whitespace, newline at EOF)

Closes #26

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/FordefiHQ/web3-provider/27)
<!-- Reviewable:end -->
