### PR TITLE
fix(provider): default skipPrediction to false (DEV-24068)

### DIFF
--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -58,7 +58,7 @@ export interface FordefiProviderConfig {
    */
   apiBaseUrl?: string;
   /**
-   * Whether to skip running a simulation before creating a new transaction, it blocks transaction creation if it fails. Defaults to true.
+   * Whether to skip running a simulation before creating a new transaction, it blocks transaction creation if it fails. Defaults to false.
    */
   skipPrediction?: boolean;
 

--- a/src/utils/transactions.ts
+++ b/src/utils/transactions.ts
@@ -172,7 +172,7 @@ export const buildEvmRawTransactionRequest = ({
   chain,
   vault,
   pushMode,
-  skipPrediction = true,
+  skipPrediction = false,
 }: BuildEvmRawTransactionRequestParams): CreateEvmRawTxRequest => {
   const { value, from, to, data } = transaction;
 


### PR DESCRIPTION
## Summary

Flip the default of `skipPrediction` from `true` to `false` in `buildEvmRawTransactionRequest`, so transactions run simulation by default. Override via `FordefiWeb3ProviderConfig.skipPrediction` still works as before.

Fixes [DEV-24068](https://fordefi.atlassian.net/browse/DEV-24068).

## Changes

- `src/utils/transactions.ts` — default parameter flipped `true` -> `false` in `buildEvmRawTransactionRequest`.
- `src/types/config.ts` — JSDoc for `FordefiWeb3ProviderConfig.skipPrediction` corrected from "Defaults to true" to "Defaults to false".
- `test/utils/transactions.test.ts` — new unit test covering: default when omitted, explicit `true`, explicit `false`.

No changes to generated OpenAPI models. Provider code in `provider.ts` keeps forwarding `this.config.skipPrediction` as-is; when undefined, the helper's new `false` default takes effect.

## Release

This PR intentionally does not bump `package.json` or touch `CHANGELOG.md` — those will go in a follow-up `release/0.3.2` PR so the `Create Release PR` workflow validation passes.

## Test plan

- [x] `yarn lint:check`
- [x] `yarn ts:check`
- [x] `yarn test test/utils/transactions.test.ts` (3/3 passing)
- [x] `yarn build` clean; verified `dist/index.mjs` now contains `skipPrediction = false` in `buildEvmRawTransactionRequest`
- [ ] CI green on `on-pull-request.yml`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/FordefiHQ/web3-provider/30)
<!-- Reviewable:end -->
